### PR TITLE
Type inference for `multiFix`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / version := "0.1.0-SNAPSHOT"
 
 inThisBuild(Seq(
   organization := "ch.epfl.lamp",
-  scalaVersion := "3.5.0-RC1-bin-SNAPSHOT",
+  scalaVersion := "3.5.1-RC1",
   version := "0.0.1",
 ))
 

--- a/src/main/scala/tyql/Query.scala
+++ b/src/main/scala/tyql/Query.scala
@@ -136,12 +136,24 @@ object Query:
                        (p: (QueryRef[P], QueryRef[Q], QueryRef[S]) => (Query[P], Query[Q], Query[S])): (Query[P], Query[Q], Query[S]) =
     ???
 
-  def multiFix[T <: Tuple](bases: Tuple.Map[T, Query])(fns: Tuple.Map[T, QueryRef] => Tuple.Map[T, Query]): Tuple.Map[T, Query] =
+
+  /** Given a Tuple `(Query[A], Query[B], ...)`, return `(A, B, ...)` */
+  type Elems[QT <: Tuple] = Tuple.InverseMap[QT, Query]
+  /** Given a Tuple `(Query[A], Query[B], ...)`, return `(Query[A], Query[B], ...)`
+   *
+   *  This isn't just the identity because the input might actually be a subtype e.g.
+   *  `(Table[A], Table[B], ...)`
+   */
+  type ToQuery[QT <: Tuple] = Tuple.Map[Elems[QT], Query]
+  /** Given a Tuple `(Query[A], Query[B], ...)`, return `(QueryRef[A], QueryRef[B], ...)` */
+  type ToQueryRef[QT <: Tuple] = Tuple.Map[Elems[QT], QueryRef]
+
+  def multiFix[QT <: Tuple](bases: QT)(using Tuple.Union[QT] <:< Query[?])(fns: ToQueryRef[QT] => ToQuery[QT]): ToQuery[QT] =
     val baseRefsAndDefs = bases.toArray.map {
       case Recursive(param, query) => (param, query)
       case base => (QueryRef()(using base.asInstanceOf[Query[?]].tag), base)
     }
-    val refs = Tuple.fromArray(baseRefsAndDefs.map(_._1)).asInstanceOf[Tuple.Map[T, QueryRef]] // ??
+    val refs = Tuple.fromArray(baseRefsAndDefs.map(_._1)).asInstanceOf[ToQueryRef[QT]]
     val defs = baseRefsAndDefs.map(_._2.asInstanceOf[Query[?]])
     val recurQueries = fns(refs)
 
@@ -154,14 +166,14 @@ object Query:
 //      implicit val ct: ClassTag[QueryRef[Any]] = ClassTag(classOf[QueryRef[Any]])
       val orderedRefs = indexes.map(refList).toArray
       val orderedQueries = indexes.map(unions)
-      val refTuple = Tuple.fromArray(orderedRefs).asInstanceOf[Tuple.Map[T, QueryRef]]
-      val queryTuple = Tuple.fromArray(indexes.map(unions).toArray).asInstanceOf[Tuple.Map[T, Query]]
-      MultiRecursive(
+      val refTuple = Tuple.fromArray(orderedRefs).asInstanceOf[ToQueryRef[QT]]
+      val queryTuple = Tuple.fromArray(indexes.map(unions).toArray).asInstanceOf[ToQuery[QT]]
+      MultiRecursive[Elems[QT]](
         refTuple,
         queryTuple
-      )(using orderedRefs.last.asInstanceOf[Query[Tuple.Last[T]]].tag)
+      )(using orderedRefs.last.asInstanceOf[Query[Tuple.Last[Elems[QT]]]].tag)
     )
-    Tuple.fromArray(listResult.toArray).asInstanceOf[Tuple.Map[T, Query]]
+    Tuple.fromArray(listResult.toArray).asInstanceOf[ToQuery[QT]]
 
   case class Recursive[R: ResultTag]($param: QueryRef[R], $query: Query[R]) extends Query[R]
 

--- a/src/main/scala/tyql/Query.scala
+++ b/src/main/scala/tyql/Query.scala
@@ -145,11 +145,9 @@ object Query:
     val defs = baseRefsAndDefs.map(_._2.asInstanceOf[Query[?]])
     val recurQueries = fns(refs)
 
-    var idx = 0
-    val unions = recurQueries.toList.map(query =>
-      Union(defs(idx).asInstanceOf[Query[Any]], query.asInstanceOf[Query[Any]], false)(using query.asInstanceOf[Query[Any]].tag)
-      idx += 1
-    )
+    val unions: List[Query[?]] = recurQueries.toList.lazyZip(defs).map:
+      case (query: Query[t], ddef) =>
+        Union(ddef.asInstanceOf[Query[t]], query, false)(using query.tag)
     val refList = refs.toList
     val listResult = unions.indices.permutations.map(indexes =>
       implicit val ct: ClassTag[Any] = ClassTag.Any

--- a/src/test/scala/test/query/RecursiveTests.scala
+++ b/src/test/scala/test/query/RecursiveTests.scala
@@ -274,8 +274,8 @@ class RecursiveTwoMultiTest extends SQLStringQueryTest[TCDB, Edge] {
   def query() =
     val pathBase = testDB.tables.edges
     val pathToABase = testDB.tables.emptyEdges
-    // TODO: can't call multiFix without the types?!
-    val (pathResult, pathToAResult) = multiFix[(Edge, Edge)](pathBase, pathToABase)((path, pathToA) =>
+
+    val (pathResult, pathToAResult) = multiFix(pathBase, pathToABase)((path, pathToA) =>
       val P = path.flatMap(p =>
         testDB.tables.edges
           .filter(e => p.y == e.x)


### PR DESCRIPTION
Also fix a bug in the implementation and update the compiler version. As noted in the commit message of the second commit, the test still does not pass.