### PR TITLE
Add a way to map a tuple (F[A], F[B], ...) into (G[A], G[B], ...)

### DIFF
--- a/src/main/scala/tyql/Query.scala
+++ b/src/main/scala/tyql/Query.scala
@@ -133,13 +133,14 @@ object Query:
     val unionsTuple = Tuple.fromArray(unions.toArray).asInstanceOf[ToQuery[QT]]
 
     refs.naturalMap([t] => finalRef =>
-      val idArg = Ref[t]()(using finalRef.tag)
-      val selectAll = Map[t, t](finalRef, Fun(idArg, idArg))(using finalRef.tag)
-      MultiRecursive[Elems[QT], t](
+      given ResultTag[t] = finalRef.tag
+      val idArg = Ref[t]()
+      val selectAll = Map[t, t](finalRef, Fun(idArg, idArg))
+      MultiRecursive(
         refs,
         unionsTuple,
         selectAll
-      )(using finalRef.tag)
+      )
     )
 //
     // TODO: need a tuple.zipWithIndex((t, I) => Tuple.Elem[I, Elems[QT]])

--- a/src/main/scala/tyql/Query.scala
+++ b/src/main/scala/tyql/Query.scala
@@ -135,7 +135,7 @@ object Query:
     refs.naturalMap([t] => finalRef =>
       given ResultTag[t] = finalRef.tag
       val idArg = Ref[t]()
-      val selectAll = Map[t, t](finalRef, Fun(idArg, idArg))
+      val selectAll = Map(finalRef, Fun(idArg, idArg))
       MultiRecursive(
         refs,
         unionsTuple,

--- a/src/main/scala/tyql/Utils.scala
+++ b/src/main/scala/tyql/Utils.scala
@@ -1,0 +1,8 @@
+package tyql
+
+object Utils:
+  extension [Base <: Tuple, F[_], G[_]](tuple: Tuple.Map[Base, F])
+    /** Map a tuple `(F[A], F[B], ...)` to a tuple `(G[A], G[B], ...)`. */
+    inline def naturalMap(f: [t] => F[t] => G[t]): Tuple.Map[Base, G] =
+      scala.runtime.Tuples.map(tuple, f.asInstanceOf).asInstanceOf[Tuple.Map[Base, G]]
+


### PR DESCRIPTION
This is useful enough that it should be added to the Scala standard library.