### PR TITLE
24.11.02 fix broken tests

### DIFF
--- a/src/main/scala/tyql/main.scala
+++ b/src/main/scala/tyql/main.scala
@@ -54,7 +54,7 @@ object Edge extends ScalaSQLTable[EdgeSS]
       statement.execute(ddl)
     )
 
-    statement.execute(s"COPY tc_edge FROM '${BuildInfo.baseDirectory}/bench/data/tc/edge.csv'")
+    statement.execute(s"COPY tc_edge FROM '${BuildInfo.baseDirectory}/bench/data/tc/data/edge.csv'")
 
     val resultSet: ResultSet = statement.executeQuery("SELECT * FROM tc_edge")
 


### PR DESCRIPTION
right now on `sbt run test` it fails due to a misplaced file:
```
[error] java.sql.SQLException: java.sql.SQLException: IO Error: No files found that match the pattern "/home/bbi/ticklish/tyql/bench/data/tc/edge.csv"
[error]         at org.duckdb.DuckDBPreparedStatement.prepare(DuckDBPreparedStatement.java:121)
[error]         at org.duckdb.DuckDBPreparedStatement.execute(DuckDBPreparedStatement.java:195)
[error]         at tyql.main$package$.main(main.scala:57)
[error]         at tyql.main.main(main.scala:39)
[error]         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
[error]         at java.base/java.lang.reflect.Method.invoke(Method.java:580)
[error] Caused by: java.sql.SQLException: IO Error: No files found that match the pattern "/home/bbi/ticklish/tyql/bench/data/tc/edge.csv"
[error]         at org.duckdb.DuckDBNative.duckdb_jdbc_prepare(Native Method)
[error]         at org.duckdb.DuckDBPreparedStatement.prepare(DuckDBPreparedStatement.java:115)
[error]         at org.duckdb.DuckDBPreparedStatement.execute(DuckDBPreparedStatement.java:195)
[error]         at tyql.main$package$.main(main.scala:57)
[error]         at tyql.main.main(main.scala:39)
[error]         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
[error]         at java.base/java.lang.reflect.Method.invoke(Method.java:580)
[error] stack trace is suppressed; run last Compile / run for the full output
[error] (Compile / run) java.sql.SQLException: java.sql.SQLException: IO Error: No files found that match the pattern "/home/bbi/ticklish/tyql/bench/data/tc/edge.csv"
[error] Total time: 1 s, completed 2 Nov 2024, 16:30:15

```